### PR TITLE
Corrections to Source OMPI and Slurm installation instructions

### DIFF
--- a/tutorial1/README.md
+++ b/tutorial1/README.md
@@ -654,8 +654,11 @@ Pacman-based systems
 # Not recommend for beginners, unless you have previous Linux expertise or
 # unless you are looking for a challenge.
 
+# The image available on Sebowa has outdated packages and package database, and a corrupted keyring
+# Run the following two commands in this order to update the keyring and installed packages
 sudo pacman -Sy archlinux-keyring
 sudo pacman -Syu
+
 sudo pacman -S <PACKAGE_NAME>
 sudo pacman -R <PACKAGE_NAME>
 ```

--- a/tutorial1/README.md
+++ b/tutorial1/README.md
@@ -654,6 +654,7 @@ Pacman-based systems
 # Not recommend for beginners, unless you have previous Linux expertise or
 # unless you are looking for a challenge.
 
+sudo pacman -Sy archlinux-keyring
 sudo pacman -Syu
 sudo pacman -S <PACKAGE_NAME>
 sudo pacman -R <PACKAGE_NAME>
@@ -731,7 +732,7 @@ You will now install and run HPL on your **head node**.
    ```bash
    # Arch
    sudo pacman -Syu
-   sudo pacman -S base-devel openmpi atlas-lapack nano wget
+   sudo pacman -S base-devel openmpi openblas nano wget
    ```
 </details>
 
@@ -807,7 +808,7 @@ You will now install and run HPL on your **head node**.
    MPdir              = /usr/lib/openmpi
 
    LAdir              = /usr/lib
-   LAlib              = $(LAdir)/libcblas.so $(LAdir)/libatlas.so
+   LAlib              = -lopenblas
 
    CC                 = mpicc
 

--- a/tutorial3/README.md
+++ b/tutorial3/README.md
@@ -378,7 +378,7 @@ Code compiled specifically for HPC hardware can use instruction sets like `AVX`,
    # architecture using `lscpu` or similar tools.
    #
    # Once again you can adjust the --prefix to install to your preferred path.
-   CFLAGS="-Ofast -march=cascadelake -mtune=cascadelake" ./configure --prefix=$HOME/opt/openmpi
+   CFLAGS="-Ofast -march=cascadelake -mtune=cascadelake" ./configure --prefix=$HOME/opt/openmpi --enable-mpi1-compatibility
 
    # Use the maximum number of threads to compile the application
    make -j$(nproc)

--- a/tutorial4/README.md
+++ b/tutorial4/README.md
@@ -1282,22 +1282,25 @@ The Slurm Workload Manager (formerly known as Simple Linux Utility for Resource 
     ControlMachine=   #DNS name of the head node
     ```
 
-    Populate the nodes and partitions at the bottom with the following two lines:
+    Populate the node's specification at the bottom with the following lines:
 
     ```conf
-    NodeName=<computenode> Sockets=<num_sockets> CoresPerSocket=<num_cpu_cores> \
-    ThreadsPerCore=<num_threads_per_core> State=UNKNOWN
+    NodeName=<computenode> Sockets=<num_sockets> CoresPerSocket=<num_cpu_cores> ThreadsPerCore=<num_threads_per_core> State=UNKNOWN
     ```
+
+    The `<computenode>` value needs to be replaced with the DNS names of your compute nodes. This can either be a comma-seperated list (e.g. `compute_node_1,compute_node_2,compute_node_3`), a hostlist expression (e.g. `compute_node_[1-3]`), or individual specification lines per compute node.
+
+    Compute nodes then need to be grouped into partitions:
 
     ```conf
     PartitionName=debug Nodes=ALL Default=YES MaxTime=INFINITE State=UP
     ```
 
-    **To check how many cores your compute node has, run `lscpu` on the compute node.** You will get output including `CPU(s)`, `Thread(s) per core`, `Core(s) per socket` and more that will help you determine what to use for the Slurm configuration.
+    **To check how many cores your compute node has, run `lscpu` on the compute node.** You will get output including `CPU(s)`, `Thread(s) per core`, `Core(s) per socket` and more that will help you determine what to use for the Slurm configuration. Use `free -m` to get details on the amount of memory in MiB available on your compute node.
 
     **Hint: if you overspec your compute resources in the definition file then Slurm will not be able to use the nodes.**
 
-12. Create Necessary Directories and Set Permissions:
+13. Create Necessary Directories and Set Permissions:
   ```bash
     sudo mkdir -p /var/spool/slurm/ctld /var/spool/slurm/d /var/log/slurm
     sudo chown -R slurm:slurm /var/spool/slurm/ctld /var/spool/slurm/d /var/log/slurm

--- a/tutorial4/README.md
+++ b/tutorial4/README.md
@@ -1240,21 +1240,21 @@ The Slurm Workload Manager (formerly known as Simple Linux Utility for Resource 
       munge -n | ssh <different node hostname or ip> unmunge
     ```
 
-6. Install dependency packages:
+5. Install dependency packages:
 
     ```bash
     sudo dnf install gcc openssl openssl-devel pam-devel numactl numactl-devel hwloc lua readline-devel ncurses-devel man2html libibmad libibumad rpm-build perl-Switch libssh2-devel mariadb-devel perl-ExtUtils-MakeMaker rrdtool-devel lua-devel hwloc-devel pmix pmix-devel
     ```
 
-7. Download the 25.11.6 version of the Slurm source code tarball (.tar.bz2) from https://download.schedmd.com/slurm/. Copy the URL for `slurm-25.11.6.bz2` from your browser and use the `wget` command to easily download files directly to your VM.
+6. Download the 25.11.6 version of the Slurm source code tarball (.tar.bz2) from https://download.schedmd.com/slurm/. Copy the URL for `slurm-25.11.6.bz2` from your browser and use the `wget` command to easily download files directly to your VM.
 
-8. Environment variables are a convenient way to store a name and value for easier recovery when they're needed. Export the version of the tarball you downloaded to the environment variable VERSION. This will make installation easier as you will see how we reference the environment variable instead of typing out the version number at every instance.
+7. Environment variables are a convenient way to store a name and value for easier recovery when they're needed. Export the version of the tarball you downloaded to the environment variable VERSION. This will make installation easier as you will see how we reference the environment variable instead of typing out the version number at every instance.
 
     ```bash
       export VERSION=25.11.6
     ```
 
-9. Build RPM packages for Slurm for installation
+8. Build RPM packages for Slurm for installation
 
     ```bash
       rpmbuild --define "_annobin_gcc_plugin %{nil}" --define "_with_pmix --with-pmix=/usr" -ta slurm-$VERSION.tar.bz2
@@ -1262,9 +1262,9 @@ The Slurm Workload Manager (formerly known as Simple Linux Utility for Resource 
 
     This should successfully generate Slurm RPMs in the `~/rpmbuild/RPMS/x86_64` directory.
 
-10.  Copy these RPMs to your compute node to install later, using `scp`.
+9.  Copy these RPMs to your compute node to install later, using `scp`.
 
-11. Install Slurm server
+10. Install Slurm server
 
     ```bash
       sudo dnf localinstall ~/rpmbuild/RPMS/x86_64/slurm-$VERSION*.rpm \
@@ -1274,7 +1274,7 @@ The Slurm Workload Manager (formerly known as Simple Linux Utility for Resource 
                             ~/rpmbuild/RPMS/x86_64/slurm-slurmctld-$VERSION*.rpm
     ```
 
-12. Setup Slurm server
+11. Setup Slurm server
 
     ```bash
       sudo cp /etc/slurm/slurm.conf.example /etc/slurm/slurm.conf
@@ -1305,11 +1305,11 @@ The Slurm Workload Manager (formerly known as Simple Linux Utility for Resource 
 
     **Hint: if you overspec your compute resources in the definition file then Slurm will not be able to use the nodes.**
 
-13. Create Necessary Directories and Set Permissions:
-  ```bash
+12. Create Necessary Directories and Set Permissions:
+    ```bash
     sudo mkdir -p /var/spool/slurm/ctld /var/spool/slurm/d /var/log/slurm
     sudo chown -R slurm:slurm /var/spool/slurm/ctld /var/spool/slurm/d /var/log/slurm
-  ```
+    ```
 
 13. **Start** and **enable** the `slurmctld` service on the head node.
 

--- a/tutorial4/README.md
+++ b/tutorial4/README.md
@@ -1238,24 +1238,24 @@ The Slurm Workload Manager (formerly known as Simple Linux Utility for Resource 
 5. Install dependency packages:
 
     ```bash
-    sudo dnf install gcc openssl openssl-devel pam-devel numactl numactl-devel hwloc lua readline-devel ncurses-devel man2html libibmad libibumad rpm-build perl-Switch libssh2-devel mariadb-devel perl-ExtUtils-MakeMaker rrdtool-devel lua-devel hwloc-devel
+    sudo dnf install gcc openssl openssl-devel pam-devel numactl numactl-devel hwloc lua readline-devel ncurses-devel man2html libibmad libibumad rpm-build perl-Switch libssh2-devel mariadb-devel perl-ExtUtils-MakeMaker rrdtool-devel lua-devel hwloc-devel pmix pmix-devel
     ```
 
-6. Download the 20.11.9 version of the Slurm source code tarball (.tar.bz2) from https://download.schedmd.com/slurm/. Copy the URL for `slurm-20.11.9.tar.bz2` from your browser and use the `wget` command to easily download files directly to your VM.
+6. Download the 25.11.6 version of the Slurm source code tarball (.tar.bz2) from https://download.schedmd.com/slurm/. Copy the URL for `slurm-25.11.6.bz2` from your browser and use the `wget` command to easily download files directly to your VM.
 
 7. Environment variables are a convenient way to store a name and value for easier recovery when they're needed. Export the version of the tarball you downloaded to the environment variable VERSION. This will make installation easier as you will see how we reference the environment variable instead of typing out the version number at every instance.
 
     ```bash
-      export VERSION=20.11.9
+      export VERSION=25.11.6
     ```
 
 8. Build RPM packages for Slurm for installation
 
     ```bash
-      sudo rpmbuild -ta slurm-$VERSION.tar.bz2
+      rpmbuild --define "_annobin_gcc_plugin %{nil}" --define "_with_pmix --with-pmix=/usr" --with multiple_slurmd -ta slurm-$VERSION.tar.bz2
     ```
 
-    This should successfully generate Slurm RPMs in the directory that you invoked the `rpmbuild` command from.
+    This should successfully generate Slurm RPMs in the `~/rpmbuild/RPMS/x86_64` directory.
 
 9.  Copy these RPMs to your compute node to install later, using `scp`.
 

--- a/tutorial4/README.md
+++ b/tutorial4/README.md
@@ -1235,21 +1235,26 @@ The Slurm Workload Manager (formerly known as Simple Linux Utility for Resource 
 
 4. **Start** and **enable** the `munge` service
 
-5. Install dependency packages:
+   Test munge encryption/decryption between the current node and a different node
+    ```bash
+      munge -n | ssh <different node hostname or ip> unmunge
+    ```
+
+6. Install dependency packages:
 
     ```bash
     sudo dnf install gcc openssl openssl-devel pam-devel numactl numactl-devel hwloc lua readline-devel ncurses-devel man2html libibmad libibumad rpm-build perl-Switch libssh2-devel mariadb-devel perl-ExtUtils-MakeMaker rrdtool-devel lua-devel hwloc-devel pmix pmix-devel
     ```
 
-6. Download the 25.11.6 version of the Slurm source code tarball (.tar.bz2) from https://download.schedmd.com/slurm/. Copy the URL for `slurm-25.11.6.bz2` from your browser and use the `wget` command to easily download files directly to your VM.
+7. Download the 25.11.6 version of the Slurm source code tarball (.tar.bz2) from https://download.schedmd.com/slurm/. Copy the URL for `slurm-25.11.6.bz2` from your browser and use the `wget` command to easily download files directly to your VM.
 
-7. Environment variables are a convenient way to store a name and value for easier recovery when they're needed. Export the version of the tarball you downloaded to the environment variable VERSION. This will make installation easier as you will see how we reference the environment variable instead of typing out the version number at every instance.
+8. Environment variables are a convenient way to store a name and value for easier recovery when they're needed. Export the version of the tarball you downloaded to the environment variable VERSION. This will make installation easier as you will see how we reference the environment variable instead of typing out the version number at every instance.
 
     ```bash
       export VERSION=25.11.6
     ```
 
-8. Build RPM packages for Slurm for installation
+9. Build RPM packages for Slurm for installation
 
     ```bash
       rpmbuild --define "_annobin_gcc_plugin %{nil}" --define "_with_pmix --with-pmix=/usr" -ta slurm-$VERSION.tar.bz2
@@ -1257,9 +1262,9 @@ The Slurm Workload Manager (formerly known as Simple Linux Utility for Resource 
 
     This should successfully generate Slurm RPMs in the `~/rpmbuild/RPMS/x86_64` directory.
 
-9.  Copy these RPMs to your compute node to install later, using `scp`.
+10.  Copy these RPMs to your compute node to install later, using `scp`.
 
-10. Install Slurm server
+11. Install Slurm server
 
     ```bash
       sudo dnf localinstall ~/rpmbuild/RPMS/x86_64/slurm-$VERSION*.rpm \
@@ -1269,7 +1274,7 @@ The Slurm Workload Manager (formerly known as Simple Linux Utility for Resource 
                             ~/rpmbuild/RPMS/x86_64/slurm-slurmctld-$VERSION*.rpm
     ```
 
-11. Setup Slurm server
+12. Setup Slurm server
 
     ```bash
       sudo cp /etc/slurm/slurm.conf.example /etc/slurm/slurm.conf

--- a/tutorial4/README.md
+++ b/tutorial4/README.md
@@ -1252,7 +1252,7 @@ The Slurm Workload Manager (formerly known as Simple Linux Utility for Resource 
 8. Build RPM packages for Slurm for installation
 
     ```bash
-      rpmbuild --define "_annobin_gcc_plugin %{nil}" --define "_with_pmix --with-pmix=/usr" --with multiple_slurmd -ta slurm-$VERSION.tar.bz2
+      rpmbuild --define "_annobin_gcc_plugin %{nil}" --define "_with_pmix --with-pmix=/usr" -ta slurm-$VERSION.tar.bz2
     ```
 
     This should successfully generate Slurm RPMs in the `~/rpmbuild/RPMS/x86_64` directory.


### PR DESCRIPTION
Tutorial 3:
Added MPI 1 compatibility flag to configuration step.

Tutorial 4:
Added test command to munge instructions.
Added pmix as a dependency.
Changed Slurm version to a less problematic release.
Fixed rpmbuild command to execute in the user's home directory and find pmix.
Clarified slurm.conf instructions further.
